### PR TITLE
Adds composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "ninsuo/symfony-collection",
+    "description": "A jQuery plugin that manages adding, deleting and moving elements from a Symfony2 collection",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Alain Tiemblo",
+            "email": "ninsuo@gmail.com"
+        }
+    ],
+    "require": {}
+}


### PR DESCRIPTION
Adds a composer.json file so people who are using Composer instead of NPM/Bower to build their assets could also import this fantastic library. Once merged, an entry could be added to Packagist for all Composer users - https://packagist.org/