### PR TITLE
Prevent inadvertent JS code executing when adding elements to the collection.

### DIFF
--- a/jquery.collection.js
+++ b/jquery.collection.js
@@ -386,10 +386,8 @@
                     var regexp = new RegExp(pregQuote(settings.prototype_name), 'g');
                     var code = $(prototype.replace(regexp, freeIndex));
                     var tmp = collection.find('> .' + settings.prefix + '-tmp');
+                    var id = $(code).find('[id]').first().attr('id');
                     tmp.empty();
-                    var regexpFind = new RegExp('([a-zA-Z][\\w:.-]+'+pregQuote(settings.prototype_name)+'[\\w:.-]+)');
-                    var matchedTemplates = regexpFind.exec(prototype);
-                    var id = matchedTemplates[1].replace(regexp, freeIndex);
                     if (container.find('#' + id).length === 0) {
 
                         if (isDuplicate) {

--- a/jquery.collection.js
+++ b/jquery.collection.js
@@ -386,8 +386,10 @@
                     var regexp = new RegExp(pregQuote(settings.prototype_name), 'g');
                     var code = $(prototype.replace(regexp, freeIndex));
                     var tmp = collection.find('> .' + settings.prefix + '-tmp');
-                    var id = tmp.html(code).find('[id]').first().attr('id');
                     tmp.empty();
+                    var regexpFind = new RegExp('([a-zA-Z][\\w:.-]+'+pregQuote(settings.prototype_name)+'[\\w:.-]+)');
+                    var matchedTemplates = regexpFind.exec(prototype);
+                    var id = matchedTemplates[1].replace(regexp, freeIndex);
                     if (container.find('#' + id).length === 0) {
 
                         if (isDuplicate) {


### PR DESCRIPTION
Version 2.0.2 inserts collection elements into the DOM temporarily in order to find the next unused id. This will cause JS code contained in the prototype to be executed. With this change set, a regular expression is used instead. This should fix issue #11.