### PR TITLE
Fixed indexing issue by providing option for backend ordering.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 nbproject
 bower.txt
 symfony-collection-demo

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # symfony-collection
-A jQuery plugin that manages adding, deleting and moving elements from a Symfony collection
+A jQuery plugin that manages adding, deleting and moving elements in a Symfony collection
 
-It is not really difficult to manage your collections using the `data-prototype` Symfony provides. But
+It is not really difficult to manage your collections using the `data-prototype` attribute Symfony provides. But
 after using collections several times, it appeared useful to me to create a jQuery plugin to do this job.
 
 This is even more true when you need your elements to be moved up and down or added at a specific position.
@@ -20,15 +20,17 @@ Your collection type should contain `prototype`, `allow_add`, `allow_remove` opt
 you require of course) and a class that will be used as a selector to run the collection plugin (if you don't want to use the id symfony generates).
 
 ```php
-->add('myCollection', 'collection', [
+$builder
     // ...
-    'allow_add' => true,
-    'allow_remove' => true,
-    'prototype' => true, // default, can be omitted
-    'attr' => [
-        'class' => 'my-selector',
-    ],
-])
+    ->add('myCollection', 'collection', [
+        // ...
+        'allow_add' => true,
+        'allow_remove' => true,
+        'prototype' => true, // default, can be omitted
+        'attr' => [
+            'class' => 'my-collection',
+        ],
+    ])
 ```
 
 Then, render your form after applying the given custom theme:
@@ -45,7 +47,7 @@ Finally, put the following code at the bottom of your page.
 <script src="{{ asset('bundles/acmedemo/js/jquery.collection.js') }}"></script>
 
 <script type="text/javascript">
-    $('.my-selector').collection();
+    $('.my-collection').collection();
 </script>
 ```
 
@@ -72,7 +74,7 @@ You can customize displayed links by setting `up`, `down`, `add`, `remove`and `d
 Default values are:
 
 ```js
-$('.collection').collection({
+$('.my-collection').collection({
     up: '<a href="#">&#x25B2;</a>',
     down: '<a href="#">&#x25BC;</a>',
     add: '<a href="#">[ + ]</a>',
@@ -89,7 +91,7 @@ and `allow_duplicate` options. By default, all buttons except `duplicate` are en
 For example, if you do not want your elements to be moved up and down, use:
 
 ```js
-$('.collection').collection({
+$('.my-collection').collection({
     allow_up: false,
     allow_down: false
 });
@@ -103,7 +105,7 @@ set following your form type configuration.
 You can set the minimum of elements allowed in the collection by using the `min` option. By default, it is disabled (set to 0).
 
 ```js
-$('.collection').collection({
+$('.my-collection').collection({
     min: 0
 });
 ```
@@ -111,7 +113,7 @@ $('.collection').collection({
 You can set the maximum of elements allowed in the collection by using the `max` option. By default, it is set to 100.
 
 ```js
-$('.collection').collection({
+$('.my-collection').collection({
     max: 100
 });
 ```
@@ -119,7 +121,7 @@ $('.collection').collection({
 You can initialize your collection with a minimum of elements created (even if they do not exist on the data object).
 
 ```js
-$('.collection').collection({
+$('.my-collection').collection({
     init_with_n_elements: 3
 });
 ```
@@ -129,7 +131,7 @@ $('.collection').collection({
 If you prefer having only one `add` button at the bottom of the collection instead of one add button per collection element, use the `add_at_the_end` option:
 
 ```js
-$('.collection').collection({
+$('.my-collection').collection({
     add_at_the_end: true
 });
 ```
@@ -141,7 +143,7 @@ you can use the `custom_add_location` option.
 
 JS:
 ```js
-$('.collection').collection({
+$('.my-collection').collection({
     custom_add_location: true
 });
 ```
@@ -161,7 +163,7 @@ By default, `move up/down` buttons are hidden on the first/last item. You can ma
 anyway by setting `hide_useless_buttons` to `false`. This can be useful if you want to style them yourself using CSS.
 
 ```js
-$('.collection').collection({
+$('.my-collection').collection({
     hide_useless_buttons: true
 });
 ```
@@ -190,7 +192,7 @@ $builder
 
 And the according plugin configuration:
 ```js
-$('.collection').collection({
+$('.my-collection').collection({
     // ...
     order_field_selector: '.order'
 });
@@ -223,7 +225,7 @@ Callback functions receive 2 arguments:
 - `element` is the element in the collection that has been added/moved/deleted.
 
 ```js
-$('.collection').collection({
+$('.my-collection').collection({
     before_add: function(collection, element) {
         if (myCondition) {
             return false;
@@ -240,7 +242,7 @@ when you are dealing with collections of form collections. But you can still do 
 following equivalents:
 
 ```js
-$('.my-selector').collection({
+$('.my-collection').collection({
     prototype_name: '{{ myForm.myCollection.vars.prototype.vars.name }}',
     allow_add: false,
     allow_remove: false,
@@ -261,7 +263,7 @@ If required, you can customize `sortable` by overriding options given to `jQuery
 By default, your collection is initialized with the following options:
 
 ```js
-$('.collection').collection({
+$('.my-collection').collection({
     drag_drop: true,
     drag_drop_options: {
         placeholder: 'ui-state-highlight'
@@ -331,7 +333,7 @@ you should not overload the `start` and `update` options in `drag_drop_options`,
 `drag_drop_start` and `drag_drop_update` options instead:
 
 ```js
-$('.collection').collection({
+$('.my-collection').collection({
     drag_drop_start: function (event, ui, elements, element) {
         // ...
     },
@@ -393,12 +395,13 @@ In the plugin options:
 - define children's selector in the `selector` attribute of `children` option (must select the root node of your children collections)
 
 ```js
-$('.parent-collection').collection({
+$('.my-collection').collection({
     prefix: 'parent',
     children: [{
         selector: '.child-collection',
         prefix: 'child',
-        ...
-    }]
+        // ...
+    }],
+    // ...
 });
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # symfony-collection
 A jQuery plugin that manages adding, deleting and moving elements from a Symfony collection
 
-This is not really difficult to manage your collections using the `data-prototype` Symfony provides. But
-after using several times collections, it appeared useful to me to create a jQuery plugin to do this job.
+It is not really difficult to manage your collections using the `data-prototype` Symfony provides. But
+after using collections several times, it appeared useful to me to create a jQuery plugin to do this job.
 
-This is even more true when you need your elements to be moved up and down or added at a specific position: as the
-form will be proceeded using field names, we should swap field contents or field names instead of moving fields themselves to get the job done. That's
-not really friendly in javascript, so this plugin also aims to deal with that.
+This is even more true when you need your elements to be moved up and down or added at a specific position.
 
 ![sample](http://ocarina.fr/medias/duplicate.png)
 
@@ -19,37 +17,36 @@ Demo source code is here: https://github.com/ninsuo/symfony-collection-demo
 # Basic usage
 
 Your collection type should contain `prototype`, `allow_add`, `allow_remove` options (depending on which buttons
-you require of course). And a class that will be used as a selector to run the collection plugin.
+you require of course) and a class that will be used as a selector to run the collection plugin (if you don't want to use the id symfony generates).
 
 ```php
-->add('myCollection', 'collection',
-   array (
-        // ...
-        'allow_add' => true,
-        'allow_remove' => true,
-        'prototype' => true,
-        'attr' => array(
-                'class' => 'my-selector',
-        ),
-))
+->add('myCollection', 'collection', [
+    // ...
+    'allow_add' => true,
+    'allow_remove' => true,
+    'prototype' => true, // default, can be omitted
+    'attr' => [
+        'class' => 'my-selector',
+    ],
+])
 ```
 
 Then, render your form after applying the given custom theme:
 
 ```jinja
-     {% form_theme myForm 'AcmeDemoBundle::jquery.collection.html.twig' %}
-     {{ form(myForm) }}
+{% form_theme myForm 'AcmeDemoBundle::jquery.collection.html.twig' %}
+{{ form(myForm) }}
 ```
 
 Finally, put the following code at the bottom of your page.
 
 ```html
-    <script src="{{ asset('js/jquery.js') }}"></script>
-    <script src="{{ asset('bundles/acmedemo/js/jquery.collection.js') }}"></script>
+<script src="{{ asset('js/jquery.js') }}"></script>
+<script src="{{ asset('bundles/acmedemo/js/jquery.collection.js') }}"></script>
 
-    <script type="text/javascript">
-        $('.my-selector').collection();
-    </script>
+<script type="text/javascript">
+    $('.my-selector').collection();
+</script>
 ```
 
 **Notes**
@@ -59,11 +56,11 @@ If you don't want to use the form theme, you should set the `name_prefix` option
 If you want to use the form theme, but already use one, you can use both with:
 
 ```jinja
-     {%
-        form_theme myForm
-            'AcmeDemoBundle::jquery.collection.html.twig'
-            'AcmeDemoBundle::my-own-form-theme.html.twig'
-     %}
+{%
+form_theme myForm
+    'AcmeDemoBundle::jquery.collection.html.twig'
+    'AcmeDemoBundle::my-own-form-theme.html.twig'
+%}
 ```
 
 # Options
@@ -75,13 +72,13 @@ You can customize displayed links by setting `up`, `down`, `add`, `remove`and `d
 Default values are:
 
 ```js
-     $('.collection').collection({
-         up: '<a href="#">&#x25B2;</a>',
-         down: '<a href="#">&#x25BC;</a>',
-         add: '<a href="#">[ + ]</a>',
-         remove: '<a href="#">[ - ]</a>',
-         duplicate: '<a href="#">[ # ]</a>'
-     });
+$('.collection').collection({
+    up: '<a href="#">&#x25B2;</a>',
+    down: '<a href="#">&#x25BC;</a>',
+    add: '<a href="#">[ + ]</a>',
+    remove: '<a href="#">[ - ]</a>',
+    duplicate: '<a href="#">[ # ]</a>'
+});
 ```
 
 **Disable links**
@@ -92,10 +89,10 @@ and `allow_duplicate` options. By default, all buttons except `duplicate` are en
 For example, if you do not want your elements to be moved up and down, use:
 
 ```js
-     $('.collection').collection({
-         allow_up: false,
-         allow_down: false
-     });
+$('.collection').collection({
+    allow_up: false,
+    allow_down: false
+});
 ```
 
 If you are using the given form theme, `allow_add`, `allow_remove` and `allow_duplicate` are automatically
@@ -106,25 +103,25 @@ set following your form type configuration.
 You can set the minimum of elements allowed in the collection by using the `min` option. By default, it is disabled (set to 0).
 
 ```js
-     $('.collection').collection({
-         min: 0
-     });
+$('.collection').collection({
+    min: 0
+});
 ```
 
 You can set the maximum of elements allowed in the collection by using the `max` option. By default, it is set to 100.
 
 ```js
-     $('.collection').collection({
-         max: 100
-     });
+$('.collection').collection({
+    max: 100
+});
 ```
 
 You can initialize your collection with a minimum of elements created (even if they do not exist on the data object).
 
 ```js
-     $('.collection').collection({
-         init_with_n_elements: 3
-     });
+$('.collection').collection({
+    init_with_n_elements: 3
+});
 ```
 
 **Only one add button at the bottom**
@@ -132,9 +129,9 @@ You can initialize your collection with a minimum of elements created (even if t
 If you prefer having only one `add` button at the bottom of the collection instead of one add button per collection element, use the `add_at_the_end` option:
 
 ```js
-     $('.collection').collection({
-         add_at_the_end: true
-     });
+$('.collection').collection({
+    add_at_the_end: true
+});
 ```
 
 **Customise add button location**
@@ -144,28 +141,66 @@ you can use the `custom_add_location` option.
 
 JS:
 ```js
-        $('.collectionA').collection({
-            custom_add_location: true
-        });
+$('.collection').collection({
+    custom_add_location: true
+});
 ```
 
 HTML:
 ```html
-        <button 
-            data-collection="collectionA" 
-            class="collection-action collection-add btn btn-success"
-        >Add element to collection</button>
+<button 
+    data-collection="collection" 
+    class="collection-action collection-add btn btn-success">
+    Add element to collection
+</button>
 ```
 
 **Hide useless buttons**
 
-By default, `move up` button is hidden on the first item, and `move down` button on the last one. You can make them appear
-anyway by setting `hide_useless_buttons` to `false`. This can be useful if you want to beautify them using CSS, for example.
+By default, `move up/down` buttons are hidden on the first/last item. You can make them appear
+anyway by setting `hide_useless_buttons` to `false`. This can be useful if you want to style them yourself using CSS.
 
 ```js
-     $('.collection').collection({
-         hide_useless_buttons: true
-     });
+$('.collection').collection({
+    hide_useless_buttons: true
+});
+```
+
+**Ordering**
+
+Of course ordering the collection elements by moving them up/down will not be persisted into your database where your collection entity probably has some kind of property for ordering, e.g.:
+
+```php
+/**
+ * @var integer
+ *
+ * @ORM\Column(name="order", type="integer")
+ */
+private $order;
+```
+
+You can provide the `order_field_selector` option, to update this field on manipulating the collection. Therefore your order property field has to be rendered in your forms with a specific class (the class you provide in `order_field_selector`).
+So your collection entity's form type might look like this:
+
+```php
+$builder
+    // ...
+    ->add('order', null, ['attr' => ['class' => 'order']])
+```
+
+And the according plugin configuration:
+```js
+$('.collection').collection({
+    // ...
+    order_field_selector: '.order'
+});
+```
+Of course you are free to hide this field in your forms by using some additonal CSS class or making it a hidden field.
+
+```php
+$builder
+    // ...
+    ->add('order', HiddenType::class, ['attr' => ['class' => 'order']])
 ```
 
 **Events**
@@ -174,27 +209,28 @@ There are `before_*` and `after_*` options that let you put callbacks before and
 elements in the collection.
 
 - `before_up`, `before_down`, `before_add` and `before_remove` are called before modifying the collection.
-The modification will be cancelled if the callback you given returned `false`, and will proceed if it returned `true`
+The modification will be cancelled if the callback you provided returned `false`, and will proceed if it returned `true`
 or `undefined`.
 
 - `after_up`, `after_down`, `after_add` and `after_remove` are called after modifying the collection.
-The modification will be reverted if the callback you given returned `false`.
 
-- `before_init` and `after_init` are called when a collection is initialized. No return value are expected.
+- `before_init` and `after_init` are called when a collection is initialized. No return value is expected.
 
 Callback functions receive 2 arguments:
 
-- `collection` references the div that contains your whole collection (the symfony2 field)
+- `collection` references the div that contains your whole collection.
 
-- `element` is the element in the collection that have been added (or moved/deleted)
+- `element` is the element in the collection that has been added/moved/deleted.
 
 ```js
-     $('.collection').collection({
-         after_add: function(collection, element) {
-            // automatic backup or whatever
-            return true;
-         }
-     });
+$('.collection').collection({
+    before_add: function(collection, element) {
+        if (myCondition) {
+            return false;
+        }
+        return true;
+    }
+});
 ```
 
 **Using the plugin without form theme**
@@ -204,37 +240,37 @@ when you are dealing with collections of form collections. But you can still do 
 following equivalents:
 
 ```js
-    $('.my-selector').collection({
-        prototype_name: '{{ myForm.myCollection.vars.prototype.vars.name }}',
-        allow_add: false,
-        allow_remove: false,
-        name_prefix:  '{{ myForm.myCollection.vars.full_name }}'
-    });
+$('.my-selector').collection({
+    prototype_name: '{{ myForm.myCollection.vars.prototype.vars.name }}',
+    allow_add: false,
+    allow_remove: false,
+    name_prefix:  '{{ myForm.myCollection.vars.full_name }}'
+});
 ```
 
-Note that only `name_prefix` option is mandatory, all other ones have default values.
+Note that only `name_prefix` option is mandatory, all others have default values.
 
 **Drag & drop support**
 
 If you are using Jquery UI and have the `sortable` component available in your application, the `drag_drop` option is
-automatically enabled and let you change your element positions using drag & drop. You can disable this behavior by explicitely
+automatically enabled and lets you change your elements position using drag & drop. You can disable this behavior by explicitly
 setting `drag_drop` option to false.
 
-If required, you can customize `sortable` by overloading options given to `jQuery.ui.sortable` using the `drag_drop_options` option.
+If required, you can customize `sortable` by overriding options given to `jQuery.ui.sortable` using the `drag_drop_options` option.
 
 By default, your collection is initialized with the following options:
 
 ```js
-     $('.collection').collection({
-         drag_drop: true,
-         drag_drop_options: {
-            placeholder: 'ui-state-highlight'
-         }
-     });
+$('.collection').collection({
+    drag_drop: true,
+    drag_drop_options: {
+        placeholder: 'ui-state-highlight'
+    }
+});
 ```
 
-Note that you should not overload `start` and `update` callbacks as they are used by this plugin, see
-`drag_drop_start` and `drag_drop_update` options in advanced usage below for more details.
+Note that you should not override `start` and `update` callbacks as they are used by this plugin, see
+`drag_drop_start` and `drag_drop_update` callback options in advanced usage below for more details.
 
 # Advanced usage
 
@@ -295,14 +331,14 @@ you should not overload the `start` and `update` options in `drag_drop_options`,
 `drag_drop_start` and `drag_drop_update` options instead:
 
 ```js
-     $('.collection').collection({
-         drag_drop_start: function (event, ui, elements, element) {
-            // ...
-         },
-         drag_drop_update: function (event, ui, elements, element) {
-            // ...
-         }
-     });
+$('.collection').collection({
+    drag_drop_start: function (event, ui, elements, element) {
+        // ...
+    },
+    drag_drop_update: function (event, ui, elements, element) {
+        // ...
+    }
+});
 ```
 
 Notes:
@@ -321,32 +357,33 @@ In your form type:
 - set a distinct `prototype_name` option and selector class for each of your collections
 
 ```php
-    ->add('collections', 'collection',
-       array (
-            'type' => 'collection',
-            'label' => 'Add, move, remove collections',
-            'options' => array (
-                    'type' => 'text',
-                    'label' => 'Add, move, remove values',
-                    'options' => array (
-                            'label' => 'Value',
-                    ),
-                    'allow_add' => true,
-                    'allow_remove' => true,
-                    'prototype' => true,
-                    'prototype_name' => '__children_name__',
-                    'attr' => array (
-                            'class' => "child-collection",
-                    ),
-            ),
+$builder
+    // ...
+    ->add('collections', 'collection', [
+        'type' => 'collection',
+        'label' => 'Add, move, remove collections',
+        'options' => [
+            'type' => 'text',
+            'label' => 'Add, move, remove values',
+            'options' => [
+                'label' => 'Value',
+            ],
             'allow_add' => true,
             'allow_remove' => true,
             'prototype' => true,
-            'prototype_name' => '__parent_name__',
-            'attr' => array (
-                    'class' => "parent-collection",
-            ),
-    ))
+            'prototype_name' => '__children_name__',
+            'attr' => [
+                'class' => "child-collection",
+            ],
+        ],
+        'allow_add' => true,
+        'allow_remove' => true,
+        'prototype' => true,
+        'prototype_name' => '__parent_name__',
+        'attr' => [
+                'class' => "parent-collection",
+        ],
+    ])
 ```
 
 In the plugin options:
@@ -356,13 +393,12 @@ In the plugin options:
 - define children's selector in the `selector` attribute of `children` option (must select the root node of your children collections)
 
 ```js
-     $('.parent-collection').collection({
-         prefix: 'parent',
-         children: [{
-             selector: '.child-collection',
-             prefix: 'child',
-             ...
-         }]
-     });
+$('.parent-collection').collection({
+    prefix: 'parent',
+    children: [{
+        selector: '.child-collection',
+        prefix: 'child',
+        ...
+    }]
+});
 ```
-

--- a/jquery.collection.js
+++ b/jquery.collection.js
@@ -331,6 +331,7 @@
                 element.fadeOut(function () {
                     $(this).remove();
                     dumpCollectionActions(collection, settings, false);
+                    setOrderValues(collection, settings);
                 });
                 settings.after_remove(collection, clone);
             }

--- a/jquery.collection.js
+++ b/jquery.collection.js
@@ -21,6 +21,10 @@
 
     $.fn.collection = function (options) {
 
+        /**
+         * DEFAULT OPTIONS
+         */
+
         var defaults = {
             container: 'body',
             allow_up: true,
@@ -71,9 +75,10 @@
             max: 100,
             add_at_the_end: false,
             prefix: 'collection',
+            prototype: null,
             prototype_name: '__name__',
             name_prefix: null,
-            elements_selector: '> div',
+            elements_selector: '.collection-element',
             children: null,
             init_with_n_elements: 0,
             hide_useless_buttons: true,
@@ -90,209 +95,77 @@
             custom_add_location: false
         };
 
-        var randomNumber = function () {
-            var rand = '' + Math.random() * 1000 * new Date().getTime();
-            return rand.replace('.', '').split('').sort(function () {
-                return 0.5 - Math.random();
-            }).join('');
-        };
+        /**
+         * METHODS
+         */
 
-        var getOrCreateId = function (prefix, obj) {
-            if (!obj.attr('id')) {
-                var generated_id;
-                do {
-                    generated_id = prefix + '_' + randomNumber();
-                } while ($('#' + generated_id).length > 0);
-                obj.attr('id', generated_id);
-            }
-            return obj.attr('id');
-        };
-
-        var getFieldValue = function (selector) {
-            try {
-                var jqElem = $(selector);
-            } catch (e) {
-                return null;
-            }
-            if (jqElem.length === 0) {
-                return null;
-            } else if (jqElem.is('input[type="checkbox"]')) {
-                return (jqElem.prop('checked') === true ? true : false);
-            } else if (jqElem.is('input[type="radio"]') && jqElem.attr('name') !== undefined) {
-                return $('input[name="' + jqElem.attr('name') + '"]:checked').val();
-            } else if (jqElem.prop('value') !== undefined) {
-                return jqElem.val();
-            } else {
-                return jqElem.html();
-            }
-        };
-
-        var putFieldValue = function (selector, value, physical) {
-            try {
-                var jqElem = $(selector);
-            } catch (e) {
-                return;
-            }
-            if (jqElem.length === 0) {
-                return;
-            } else if (jqElem.is('input[type="checkbox"]')) {
-                if (value) {
-                    jqElem.attr('checked', true);
-                } else {
-                    jqElem.removeAttr('checked');
-                }
-            } else if (jqElem.prop('value') !== undefined) {
-                if (physical) {
-                    jqElem.attr('value', value);
-                } else {
-                    jqElem.val(value);
-                }
-            } else {
-                jqElem.html(value);
-            }
-        };
-
+        /**
+         * Shortcut to check callbacks.
+         *
+         * @param value
+         * @returns {boolean|*}
+         */
         var trueOrUndefined = function (value) {
             return undefined === value || value;
         };
 
+        /**
+         * Get regex for prototype field name placeholder (default: __name__)
+         *
+         * @param string
+         * @returns {string}
+         */
         var pregQuote = function (string) {
             return (string + '').replace(/[.?*+^$[\]\\(){}|-]/g, "\\$&");
         };
 
-        var replaceAttrData = function (elements, index, toReplace, replaceWith) {
-
-            var replaceAttrDataNode = function (node) {
-                var jqNode = $(node);
-                $.each(node.attributes, function (i, attrib) {
-                    if ($.type(attrib.value) === 'string') {
-                        jqNode.attr(attrib.name.replace(toReplace, replaceWith), attrib.value.replace(toReplace, replaceWith));
-                    }
-                });
-                $.each(jqNode.data(), function (name, value) {
-                    if ($.type(value) === 'string') {
-                        jqNode.data(name.replace(toReplace, replaceWith), value.replace(toReplace, replaceWith));
-                    }
-                });
-            };
-
-            var element = elements.eq(index);
-            replaceAttrDataNode(element[0]);
-            element.find('*').each(function () {
-                replaceAttrDataNode(this);
-            });
-        };
-
-        var changeElementIndex = function (collection, elements, settings, index, oldIndex, newIndex) {
-            var toReplace = new RegExp(pregQuote(settings.name_prefix + '[' + oldIndex + ']'), 'g');
-            var replaceWith = settings.name_prefix + '[' + newIndex + ']';
-            replaceAttrData(elements, index, toReplace, replaceWith);
-
-            toReplace = new RegExp(pregQuote(collection.attr('id') + '_' + oldIndex), 'g');
-            replaceWith = collection.attr('id') + '_' + newIndex;
-            replaceAttrData(elements, index, toReplace, replaceWith);
-        };
-
-        var changeHtmlIndex = function (collection, settings, html, oldIndex, newIndex) {
-            var toReplace = new RegExp(pregQuote(settings.name_prefix + '[' + oldIndex + ']'), 'g');
-            var replaceWith = settings.name_prefix + '[' + newIndex + ']';
-            html = html.replace(toReplace, replaceWith);
-
-            toReplace = new RegExp(pregQuote(collection.attr('id') + '_' + oldIndex), 'g');
-            replaceWith = collection.attr('id') + '_' + newIndex;
-            html = html.replace(toReplace, replaceWith);
-
-            return html;
-        };
-
-        var putFieldValuesInDom = function (element) {
-            $(element).find(':input').each(function (index, inputObj) {
-                putFieldValue(inputObj, getFieldValue(inputObj), true);
-            });
-        };
-
-        var swapElements = function (collection, elements, oldIndex, newIndex) {
-
-            var settings = collection.data('collection-settings');
-
-            changeElementIndex(collection, elements, settings, oldIndex, oldIndex, '__swap__');
-            changeElementIndex(collection, elements, settings, newIndex, newIndex, oldIndex);
-            changeElementIndex(collection, elements, settings, oldIndex, '__swap__', newIndex);
-
-            elements.eq(oldIndex).insertBefore(elements.eq(newIndex));
-            if (newIndex > oldIndex) {
-                elements.eq(newIndex).insertBefore(elements.eq(oldIndex));
-            } else {
-                elements.eq(newIndex).insertAfter(elements.eq(oldIndex));
-            }
-
-            return collection.find(settings.elements_selector);
-        };
-
-        var swapElementsUp = function (collection, elements, settings, oldIndex, newIndex) {
-            for (var i = oldIndex + 1; (i <= newIndex); i++) {
-                elements = swapElements(collection, elements, i, i - 1);
-            }
-            return collection.find(settings.elements_selector);
-        };
-
-        var swapElementsDown = function (collection, elements, settings, oldIndex, newIndex) {
-            for (var i = oldIndex - 1; (i >= newIndex); i--) {
-                elements = swapElements(collection, elements, i, i + 1);
-            }
-            return collection.find(settings.elements_selector);
-        };
-
-        var shiftElementsUp = function (collection, elements, settings, index) {
-            for (var i = index + 1; i < elements.length; i++) {
-                elements = swapElements(collection, elements, i - 1, i);
-            }
-            return collection.find(settings.elements_selector);
-        };
-
-        var shiftElementsDown = function (collection, elements, settings, index) {
-            for (var i = elements.length - 2; i > index; i--) {
-                elements = swapElements(collection, elements, i + 1, i);
-            }
-            return collection.find(settings.elements_selector);
-        };
-
+        /**
+         * Initializes collection actions.
+         *
+         * @param collection
+         * @param settings
+         * @param isInitialization
+         */
         var dumpCollectionActions = function (collection, settings, isInitialization) {
-            var init = collection.find('.' + settings.prefix + '-tmp').length === 0;
             var elements = collection.find(settings.elements_selector);
 
+            // add rescue-add button on initialization
+            if (settings.allow_add && settings.add && isInitialization) {
+                collection.append(
+                    $(settings.add)
+                        .addClass(settings.prefix + '-action ' + settings.prefix + '-rescue-add')
+                        .data('collection', collection.attr('id'))
+                );
+            }
+
+            // handle all add buttons display
             if (settings.allow_add) {
-                if (init) {
-                    collection.append('<span class="' + settings.prefix + '-tmp"></span>');
-                    if (settings.add) {
-                        collection.append(
-                            $(settings.add)
-                                .addClass(settings.prefix + '-action ' + settings.prefix + '-rescue-add')
-                                .data('collection', collection.attr('id'))
-                        );
-                    }
+                var rescueAdd = collection.find('.' + settings.prefix + '-rescue-add');
+                var adds = collection.find('.' + settings.prefix + '-add');
+
+                // handle rescue-add button display
+                rescueAdd.css('display', '');
+                if (!settings.add_at_the_end && adds.length > 0 || settings.custom_add_location) {
+                    rescueAdd.css('display', 'none');
+                }
+
+                // don't show any add button if maximum elements are reached
+                if (elements.length >= settings.max) {
+                    collection.find('.' + settings.prefix + '-add, .' + settings.prefix + '-rescue-add, .' + settings.prefix + '-duplicate').css('display', 'none');
                 }
             }
 
-            if (isInitialization) {
-                var container = $(settings.container);
-                var button = collection.find('.' + settings.prefix + '-add, .' + settings.prefix + '-rescue-add, .' + settings.prefix + '-duplicate').first();
-                while (elements.length < settings.init_with_n_elements) {
-                    var element = elements.length > 0 ? elements.last() : undefined;
-                    var index = elements.length + 1;
-                    elements = doAdd(container, button, collection, settings, elements, element, index, false);
-                }
-            }
-
-            elements.each(function (index) {
+            elements.each(function () {
                 var element = $(this);
 
+                // look for actions container, add if not exists
                 var actions = element.find('.' + settings.prefix + '-actions').addBack().filter('.' + settings.prefix + '-actions');
                 if (actions.length === 0) {
                     actions = $('<div class="' + settings.prefix + '-actions"></div>');
                     element.append(actions);
                 }
 
+                // prepare buttons
                 var buttons = [
                     {
                         'enabled': settings.allow_remove,
@@ -322,6 +195,7 @@
                     }
                 ];
 
+                // add buttons
                 $.each(buttons, function (i, button) {
                     if (button.enabled) {
                         var action = element.find('.' + button.selector);
@@ -343,30 +217,24 @@
                         }
                         action
                             .addClass(settings.prefix + '-action')
-                            .data('collection', collection.attr('id'))
-                            .data(settings.prefix + '-element', getOrCreateId(collection.attr('id') + '_' + index, element));
+                            .data('collection', collection.attr('id'));
                     } else {
                         element.find('.' + button.selector).css('display', 'none');
                     }
                 });
             });
-
-            if (settings.allow_add) {
-                var rescueAdd = collection.find('.' + settings.prefix + '-rescue-add').css('display', '');
-                var adds = collection.find('.' + settings.prefix + '-add');
-                if (!settings.add_at_the_end && adds.length > 0 || settings.custom_add_location) {
-                    rescueAdd.css('display', 'none');
-                }
-                if (elements.length >= settings.max) {
-                    collection.find('.' + settings.prefix + '-add, .' + settings.prefix + '-rescue-add, .' + settings.prefix + '-duplicate').css('display', 'none');
-                }
-            }
-
         };
 
+        /**
+         * Enables the plugin on child collections.
+         *
+         * @param collection
+         * @param element
+         * @param settings
+         */
         var enableChildrenCollections = function (collection, element, settings) {
             if (settings.children) {
-                $.each(settings.children, function (index, childrenSettings) {
+                $.each(settings.children, function (i, childrenSettings) {
                     if (!childrenSettings.selector) {
                         console.log("jquery.collection.js: given collection " + collection.attr('id') + " has children collections, but children's root selector is undefined.");
                         return true;
@@ -380,252 +248,261 @@
             }
         };
 
-        var doAdd = function (container, that, collection, settings, elements, element, index, isDuplicate) {
+        /**
+         * Adds items.
+         *
+         * @param container
+         * @param that
+         * @param collection
+         * @param settings
+         * @param elements
+         * @param element
+         * @param isDuplicate
+         * @returns {*}
+         */
+        var doAdd = function (container, that, collection, settings, elements, element, isDuplicate) {
             if (elements.length < settings.max && (isDuplicate && trueOrUndefined(settings.before_duplicate(collection, element)) || trueOrUndefined(settings.before_add(collection, element)))) {
-                var prototype = collection.data('prototype');
-                var freeIndex = elements.length;
-                var regexp = new RegExp(pregQuote(settings.prototype_name), 'g');
-                var code = $(prototype.replace(regexp, freeIndex));
-                var tmp = collection.find('> .' + settings.prefix + '-tmp');
-                var id = $(code).find('[id]').first().attr('id');
 
-                if (isDuplicate) {
-                    putFieldValuesInDom(elements.eq(index));
-                    var oldHtml = $("<div/>").append(elements.eq(index).clone()).html();
-                    var newHtml = changeHtmlIndex(collection, settings, oldHtml, index, freeIndex);
-                    code = $('<div/>').html(newHtml).contents();
-                    tmp.before(code).find(settings.prefix + '-actions').remove();
-                } else {
-                    tmp.before(code);
-                }
+                // increase index
+                collection.data('index', parseInt(collection.data('index')) + 1);
 
-                elements = collection.find(settings.elements_selector);
-                var action = code.find('.' + settings.prefix + '-add, .' + settings.prefix + '-duplicate');
-                if (action.length > 0) {
-                    action.addClass(settings.prefix + '-action').data('collection', collection.attr('id'));
-                }
+                var prototype = collection.data('prototype'),
+                    index = collection.data('index'),
+                    regexp = new RegExp(pregQuote(settings.prototype_name), 'g'),
+                    code = $(prototype.replace(regexp, index)).addClass(settings.elements_selector.replace('.', ''));
 
-                if (that.data(settings.prefix + '-element') !== undefined) {
-                    var index = elements.index($('#' + that.data(settings.prefix + '-element')));
-                    if (index !== -1) {
-                        elements = shiftElementsDown(collection, elements, settings, index);
+                if (element.length) { // add after or duplicate element
+                    if (isDuplicate) {
+                        code = element.clone();
+                        // TODO: replace index
                     }
+                    code.hide();
+                    element.after(code);
+                    code.fadeIn();
+                    // TODO: handle timing issue (needs callback)
+                } else { // add element to end of collection
+                    code.hide();
+                    collection.append(code);
+                    code.fadeIn();
                 }
 
                 enableChildrenCollections(collection, code, settings);
 
-                if ((isDuplicate && !trueOrUndefined(settings.after_duplicate(collection, code))) || !trueOrUndefined(settings.after_add(collection, code))) {
-                    if (index !== -1) {
-                        elements = shiftElementsUp(collection, elements, settings, index + 1);
-                    }
-                    code.remove();
-                }
+                // fire event
+                isDuplicate ? settings.after_duplicate(collection, code) : settings.after_add(collection, code);
             }
 
             return elements;
         };
 
-        var doDelete = function (collection, settings, elements, element, index) {
+        /**
+         * Remove element from collection.
+         *
+         * @param collection
+         * @param settings
+         * @param elements
+         * @param element
+         * @returns {*}
+         */
+        var doDelete = function (collection, settings, elements, element) {
             if (elements.length > settings.min && trueOrUndefined(settings.before_remove(collection, element))) {
-                elements = shiftElementsUp(collection, elements, settings, index);
-                var toDelete = elements.last();
-                var backup = toDelete.clone({withDataAndEvents: true});
-                toDelete.remove();
-                if (!trueOrUndefined(settings.after_remove(collection, backup))) {
-                    collection.find('> .' + settings.prefix + '-tmp').before(backup);
-                    elements = collection.find(settings.elements_selector);
-                    elements = shiftElementsDown(collection, elements, settings, index - 1);
-                }
+                var clone = element.clone();
+                element.fadeOut(function () {
+                    $(this).remove();
+                });
+                settings.after_remove(collection, clone);
             }
 
             return elements;
         };
 
-        var doUp = function (collection, settings, elements, element, index) {
-            if (index !== 0 && trueOrUndefined(settings.before_up(collection, element))) {
-                elements = swapElements(collection, elements, index, index - 1);
-                if (!trueOrUndefined(settings.after_up(collection, element))) {
-                    elements = swapElements(collection, elements, index - 1, index);
-                }
+        /**
+         * Move element up in the collection, if 'before_up' callback doesn't abort.
+         *
+         * @param collection
+         * @param settings
+         * @param elements
+         * @param element
+         * @returns {*}
+         */
+        var doUp = function (collection, settings, elements, element) {
+            if (element.prev().length && trueOrUndefined(settings.before_up(collection, element))) {
+                element.after(element.prev());
+                settings.after_up(collection, elements);
             }
 
             return elements;
         };
 
-        var doDown = function (collection, settings, elements, element, index) {
-            if (index !== (elements.length - 1) && trueOrUndefined(settings.before_down(collection, element))) {
-                elements = swapElements(collection, elements, index, index + 1);
-                if (!trueOrUndefined(settings.after_down(collection, elements))) {
-                    elements = swapElements(collection, elements, index + 1, index);
-                }
+        /**
+         * Move element down in the collection, if 'before_down' callback doesn't abort.
+         *
+         * @param collection
+         * @param settings
+         * @param elements
+         * @param element
+         * @returns {*}
+         */
+        var doDown = function (collection, settings, elements, element) {
+            if (element.next().length && trueOrUndefined(settings.before_down(collection, element))) {
+                element.before(element.next());
+                settings.after_up(collection, elements);
             }
 
             return elements;
         };
 
-        var elems = $(this);
+        /**
+         * INITIALIZATION
+         */
 
-        if (elems.length === 0) {
-            console.log("jquery.collection.js: given collection selector does not exist.");
+        var settings = $.extend(true, {}, defaults, options);
+
+        if ($(settings.container).length === 0) {
+            console.log("jquery.collection.js: a container should exist to handle events (basically, a <body> tag).");
             return false;
         }
 
-        elems.each(function () {
+        var collection = $(this);
 
-            var settings = $.extend(true, {}, defaults, options);
+        settings.before_init(collection);
 
-            if ($(settings.container).length === 0) {
-                console.log("jquery.collection.js: a container should exist to handle events (basically, a <body> tag).");
-                return false;
-            }
-
-            var elem = $(this);
-            if (elem.data('collection') !== undefined) {
-                var collection = $('#' + elem.data('collection'));
-                if (collection.length === 0) {
-                    console.log("jquery.collection.js: given collection id does not exist.");
-                    return true;
-                }
+        // merge data-attributes into settings
+        if (!settings.prototype) {
+            if (collection.data('prototype') !== undefined) {
+                settings.prototype = collection.data('prototype');
             } else {
-                collection = elem;
-            }
-
-            settings.before_init(collection);
-
-            if (collection.data('prototype') === null) {
-                console.log("jquery.collection.js: given collection field has no prototype, check that your field has the prototype option set to true.");
+                console.log("jquery.collection.js: given collection field has no prototype, check that your field has the prototype option set to true (in symfony form builder) or provide the prototype option yourself.");
                 return true;
             }
+        }
+        if (collection.data('prototype-name') !== undefined) {
+            settings.prototype_name = collection.data('prototype-name');
+        }
+        if (collection.data('allow-add') !== undefined) {
+            settings.allow_add = collection.data('allow-add');
+            settings.allow_duplicate = settings.allow_add ? settings.allow_duplicate : false;
+        }
+        if (collection.data('allow-remove') !== undefined) {
+            settings.allow_remove = collection.data('allow-remove');
+        }
+        if (collection.data('name-prefix') !== undefined) {
+            settings.name_prefix = collection.data('name-prefix');
+        }
+        if (!settings.name_prefix) {
+            console.log("jquery.collection.js: the prefix used in descendant field names is mandatory, you can set it using 2 ways:");
+            console.log("jquery.collection.js: - use the form theme given with this plugin source");
+            console.log("jquery.collection.js: - set name_prefix option to  '{{ formView.myCollectionField.vars.full_name }}'");
+            return true;
+        }
 
-            if (collection.data('prototype-name') !== undefined) {
-                settings.prototype_name = collection.data('prototype-name');
-            }
-            if (collection.data('allow-add') !== undefined) {
-                settings.allow_add = collection.data('allow-add');
-                settings.allow_duplicate = collection.data('allow-add') ? settings.allow_duplicate : false;
-            }
-            if (collection.data('allow-remove') !== undefined) {
-                settings.allow_remove = collection.data('allow-remove');
-            }
-            if (collection.data('name-prefix') !== undefined) {
-                settings.name_prefix = collection.data('name-prefix');
-            }
+        // make sure init_with_n_elements is in the min/max range if provided
+        if (settings.init_with_n_elements < settings.min) {
+            settings.init_with_n_elements = settings.min;
+        }
+        if (settings.init_with_n_elements > settings.max) {
+            settings.init_with_n_elements = settings.max;
+        }
 
-            if (!settings.name_prefix) {
-                console.log("jquery.collection.js: the prefix used in descendant field names is mandatory, you can set it using 2 ways:");
-                console.log("jquery.collection.js: - use the form theme given with this plugin source");
-                console.log("jquery.collection.js: - set name_prefix option to  '{{ formView.myCollectionField.vars.full_name }}'");
-                return true;
-            }
+        // save processed settings to data attribute
+        collection.data('collection-settings', settings);
 
-            if (settings.init_with_n_elements < settings.min) {
-                settings.init_with_n_elements = settings.min;
-            }
-
-            if (settings.drag_drop && settings.allow_up && settings.allow_down) {
-                var oldPosition;
-                var newPosition;
-                if (typeof jQuery.ui === 'undefined' || typeof jQuery.ui.sortable === 'undefined') {
-                    settings.drag_drop = false;
-                } else {
-                    collection.sortable($.extend(true, {}, {
-                        start: function (event, ui) {
-                            var elements = collection.find(settings.elements_selector);
-                            var element = ui.item;
-                            var that = $(this);
-                            if (!trueOrUndefined(settings.drag_drop_start(event, ui, elements, element))) {
-                                that.sortable("cancel");
-                                return;
-                            }
-                            ui.placeholder.height(ui.item.height());
-                            ui.placeholder.width(ui.item.width());
-                            oldPosition = elements.index(element);
-                        },
-                        update: function (event, ui) {
-                            var elements = collection.find(settings.elements_selector);
-                            var element = ui.item;
-                            var that = $(this);
-                            that.sortable("cancel");
-                            if (false === settings.drag_drop_update(event, ui, elements, element) || !(newPosition - oldPosition > 0 ? trueOrUndefined(settings.before_up(collection, element)) : trueOrUndefined(settings.before_down(collection, element)))) {
-                                return;
-                            }
-                            newPosition = elements.index(element);
-                            elements = collection.find(settings.elements_selector);
-                            if (1 === Math.abs(newPosition - oldPosition)) {
-                                elements = swapElements(collection, elements, oldPosition, newPosition);
-                                if (!(newPosition - oldPosition > 0 ? trueOrUndefined(settings.after_up(collection, element)) : trueOrUndefined(settings.after_down(collection, element)))) {
-                                    elements = swapElements(collection, elements, newPosition, oldPosition);
-                                }
-                            } else {
-                                if (oldPosition < newPosition) {
-                                    elements = swapElementsUp(collection, elements, settings, oldPosition, newPosition);
-                                    if (!(newPosition - oldPosition > 0 ? trueOrUndefined(settings.after_up(collection, element)) : trueOrUndefined(settings.after_down(collection, element)))) {
-                                        elements = swapElementsDown(collection, elements, settings, newPosition, oldPosition);
-                                    }
-                                } else {
-                                    elements = swapElementsDown(collection, elements, settings, oldPosition, newPosition);
-                                    if (!(newPosition - oldPosition > 0 ? trueOrUndefined(settings.after_up(collection, element)) : trueOrUndefined(settings.after_down(collection, element)))) {
-                                        elements = swapElementsUp(collection, elements, settings, newPosition, oldPosition);
-                                    }
-                                }
-                            }
-                            dumpCollectionActions(collection, settings, false);
-                        }
-                    }, settings.drag_drop_options));
-                }
-            }
-
-            collection.data('collection-settings', settings);
-
-            var container = $(settings.container);
-
-            container
-                    .off('click', '.' + settings.prefix + '-action')
-                    .on('click', '.' + settings.prefix + '-action', function (e) {
-
-                        var that = $(this);
-
-                        var collection = $('#' + that.data('collection'));
-                        var settings = collection.data('collection-settings');
-
-                        if (undefined === settings) {
-                            var collection = $('#' + that.data('collection')).find('.' + that.data('collection') + '-collection');
-                            var settings = collection.data('collection-settings');
-                            if (undefined === settings) {
-                                throw "Can't find collection: " + that.data('collection');
-                            }
-                        }
-
-                        var elements = collection.find(settings.elements_selector);
-                        var element = that.data(settings.prefix + '-element') ? $('#' + that.data(settings.prefix + '-element')) : undefined;
-                        var index = element && element.length ? elements.index(element) : -1;
-
-                        var isDuplicate = that.is('.' + settings.prefix + '-duplicate');
-                        if ((that.is('.' + settings.prefix + '-add') || that.is('.' + settings.prefix + '-rescue-add') || isDuplicate) && settings.allow_add) {
-                            elements = doAdd(container, that, collection, settings, elements, element, index, isDuplicate);
-                        }
-
-                        if (that.is('.' + settings.prefix + '-remove') && settings.allow_remove) {
-                            elements = doDelete(collection, settings, elements, element, index);
-                        }
-
-                        if (that.is('.' + settings.prefix + '-up') && settings.allow_up) {
-                            elements = doUp(collection, settings, elements, element, index);
-                        }
-
-                        if (that.is('.' + settings.prefix + '-down') && settings.allow_down) {
-                            elements = doDown(collection, settings, elements, element, index);
-                        }
-
-                        dumpCollectionActions(collection, settings, false);
-                        e.preventDefault();
-                    });
-
-            dumpCollectionActions(collection, settings, true);
-            enableChildrenCollections(collection, null, settings);
-
-            settings.after_init(collection);
+        // add element class to all elements if not exists
+        collection.find('> div').each(function (i, element) {
+            $(element).addClass(settings.elements_selector.replace('.', ''));
         });
+
+        // add initial elements (defined by init_with_n_elements)
+        var elements = collection.find(settings.elements_selector);
+        while (elements.length < settings.init_with_n_elements) {
+            elements = doAdd($(settings.container), button, collection, settings, elements, null, false);
+        }
+
+        // calc index
+        collection.data('index', elements.length);
+
+        // handle drag/drop support from jquery ui and trigger events
+        if (settings.drag_drop && settings.allow_up && settings.allow_down) {
+            var oldPosition;
+            var newPosition;
+            if (typeof jQuery.ui === 'undefined' || typeof jQuery.ui.sortable === 'undefined') {
+                settings.drag_drop = false;
+            } else {
+                collection.sortable($.extend(true, {}, {
+                    start: function (event, ui) {
+                        var elements = collection.find(settings.elements_selector);
+                        var element = ui.item;
+                        var that = $(this);
+                        if (!trueOrUndefined(settings.drag_drop_start(event, ui, elements, element))) {
+                            that.sortable("cancel");
+                            return;
+                        }
+                        ui.placeholder.height(ui.item.height());
+                        ui.placeholder.width(ui.item.width());
+                        oldPosition = elements.index(element);
+                    },
+                    update: function (event, ui) {
+                        var elements = collection.find(settings.elements_selector);
+                        var element = ui.item;
+                        var that = $(this);
+                        newPosition = elements.index(element);
+                        if (false === settings.drag_drop_update(event, ui, elements, element) || !(newPosition - oldPosition < 0 ? trueOrUndefined(settings.before_up(collection, element)) : trueOrUndefined(settings.before_down(collection, element)))) {
+                            that.sortable("cancel");
+                            return;
+                        }
+                        dumpCollectionActions(collection, settings, false);
+                        newPosition - oldPosition < 0 ? trueOrUndefined(settings.after_up(collection, element)) : trueOrUndefined(settings.after_down(collection, element));
+                    }
+                }, settings.drag_drop_options));
+            }
+        }
+
+        // add events to action buttons
+        var container = $(settings.container);
+        container
+            .off('click', '.' + settings.prefix + '-action')
+            .on('click', '.' + settings.prefix + '-action', function (e) {
+
+                var that = $(this);
+
+                var collection = $('#' + that.data('collection')),
+                    settings = collection.data('collection-settings'),
+                    elements = collection.find(settings.elements_selector);
+
+                var element = that.parents(settings.elements_selector);
+
+                if (that.is('.' + settings.prefix + '-duplicate') && settings.allow_add && settings.allow_duplicate) {
+                    doAdd(container, that, collection, settings, elements, element, true);
+                }
+
+                if (that.is('.' + settings.prefix + '-rescue-add') && settings.allow_add) {
+                    doAdd(container, that, collection, settings, elements, element, false);
+                }
+
+                if (that.is('.' + settings.prefix + '-add') && settings.allow_add) {
+                    doAdd(container, that, collection, settings, elements, element, false);
+                }
+
+                if (that.is('.' + settings.prefix + '-remove') && settings.allow_remove) {
+                    doDelete(collection, settings, elements, element);
+                }
+
+                if (that.is('.' + settings.prefix + '-up') && settings.allow_up) {
+                    doUp(collection, settings, elements, element);
+                }
+
+                if (that.is('.' + settings.prefix + '-down') && settings.allow_down) {
+                    doDown(collection, settings, elements, element);
+                }
+
+                dumpCollectionActions(collection, settings, false);
+                e.preventDefault();
+            });
+
+        dumpCollectionActions(collection, settings, true);
+        enableChildrenCollections(collection, null, settings);
+
+        settings.after_init(collection);
 
         return true;
     };

--- a/jquery.collection.js
+++ b/jquery.collection.js
@@ -92,7 +92,8 @@
             drag_drop_update: function (event, ui) {
                 return true;
             },
-            custom_add_location: false
+            custom_add_location: false,
+            order_field_selector: null
         };
 
         /**
@@ -223,6 +224,23 @@
                     }
                 });
             });
+        };
+
+        /**
+         * Sets the order values in the order fields if order_field_selector is set.
+         *
+         * @param collection
+         * @param settings
+         */
+        var setOrderValues = function (collection, settings) {
+            if (settings.order_field_selector) {
+                var orderValue = 1,
+                    elements = collection.find(settings.elements_selector);
+                elements.each(function (i, element) {
+                    $(element).find(settings.order_field_selector).val(orderValue);
+                    orderValue++;
+                });
+            }
         };
 
         /**
@@ -455,6 +473,7 @@
                             return;
                         }
                         dumpCollectionActions(collection, settings, false);
+                        setOrderValues(collection, settings);
                         newPosition - oldPosition < 0 ? trueOrUndefined(settings.after_up(collection, element)) : trueOrUndefined(settings.after_down(collection, element));
                     }
                 }, settings.drag_drop_options));
@@ -500,6 +519,7 @@
                 }
 
                 dumpCollectionActions(collection, settings, false);
+                setOrderValues(collection, settings);
                 e.preventDefault();
             });
 

--- a/jquery.collection.js
+++ b/jquery.collection.js
@@ -274,12 +274,15 @@
                 if (element.length) { // add after or duplicate element
                     if (isDuplicate) {
                         code = element.clone();
-                        // TODO: replace index
+                        // replace indexes
+                        $(':input', code).each(function(i, input) {
+                            $(input).attr('id', $(input).attr('id').replace(/_\d+_/, '_' + index + '_'));
+                            $(input).attr('name', $(input).attr('name').replace(/\[\d+\]/, '[' + index + ']'));
+                        });
                     }
                     code.hide();
                     element.after(code);
                     code.fadeIn();
-                    // TODO: handle timing issue (needs callback)
                 } else { // add element to end of collection
                     code.hide();
                     collection.append(code);
@@ -309,6 +312,7 @@
                 var clone = element.clone();
                 element.fadeOut(function () {
                     $(this).remove();
+                    dumpCollectionActions(collection, settings, false);
                 });
                 settings.after_remove(collection, clone);
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony-collection",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "homepage": "http://symfony-collection.fuz.org",
     "description": "A jQuery plugin that manages adding, deleting and moving elements from a Symfony2 collection",
     "keywords": [


### PR DESCRIPTION
According to: https://github.com/ninsuo/symfony-collection/issues/42#issuecomment-268007479

This PR changes the indexing behavior completely. Instead of swapping field contents, the entire forms are now swapped. This preserves the relation between IDs and entities in the database while revealing the issue of missing support for server-side ordering of collection entries, which this PR also solves by providing a new 'order_field_selector' option. So if the forms of the collection entries contain an order field, these fields will be updated automatically on every manipulation of the collection.

Fixes #42 #20