### PR TITLE
Fix nested collection settings update on move

### DIFF
--- a/jquery.collection.js
+++ b/jquery.collection.js
@@ -205,7 +205,7 @@
 
             if (settings.children) {
                 $.each(settings.children, function(key, child) {
-                    var childCollection = collection.find(child.selector);
+                    var childCollection = collection.find(child.selector).eq(index);
                     var childSettings = childCollection.data('collection-settings');
                     childSettings.name_prefix = childSettings.name_prefix.replace(toReplace, replaceWith);
                     childCollection.data('collection-settings', childSettings);


### PR DESCRIPTION
When moving a parent collection up, the child collection settings were not properly
updated.

How to reproduce:
On the [demo website](https://symfony-collection.fuz.org/symfony3/advanced/collectionOfCollections), follow this steps:
1. Move a collection up
2. Move a child element and see that its input name attribute didn't changed

Fix #73