### PR TITLE
Ability to change the parent selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ nbproject
 symfony2.x
 symfony3.x
 symfony-collection-demo
+.idea

--- a/README.md
+++ b/README.md
@@ -481,13 +481,28 @@ But you may need to put elements deeper in the dom, for example when you put ele
     </table>
 ```
 
-In that case, parent selector should be `table.collection tbody`.
+In that example, parent selector should be `table.collection tbody`.
+
+Note that you can use `%id%` inside `elements_parent_selector`, it will be automatically replaced by the
+collection's id. This is particularly useful when you're dealing with nested collections.
+
+Example:
+
+```js
+     $('.collection').collection({
+        // ...
+        children: [{
+            // ...
+            elements_parent_selector: '%id% tbody'
+        }]
+     });
+```
 
 Default value:
 
 ```js
      $('.collection').collection({
-        elements_parent_selector: null // will be the collection itself
+        elements_parent_selector: '%id%' // will be the collection itself
      });
 ```
 

--- a/README.md
+++ b/README.md
@@ -455,6 +455,42 @@ to display each element of your collection in a table, so you can change this va
 You may use `> tr`, `thead > tr` or more specifically `tr.item` or just `.item` if you set `class="item"` at the top
 of your item's form theme. The goal is to reference each item in the collection whatever the markup.
 
+**Change the parent selector**
+
+To be able to add elements to the collection, this plugin should be aware of the dom object that will contain them.
+
+By default, your collection elements will be located just below your collection, for example:
+
+```html
+    <div id="collection">
+       <div id="child_0">(...)</div>
+       <div id="child_1">(...)</div>
+       <div id="child_2">(...)</div>
+    </div>
+```
+
+But you may need to put elements deeper in the dom, for example when you put elements in a table:
+
+```html
+    <table id="collection">
+        <tbody>
+            <tr id="child_0">(...)</tr>
+            <tr id="child_1">(...)</tr>
+            <tr id="child_2">(...)</tr>
+        </tbody>
+    </table>
+```
+
+In that case, parent selector should be `table.collection tbody`.
+
+Default value:
+
+```js
+     $('.collection').collection({
+        elements_parent_selector: null // will be the collection itself
+     });
+```
+
 # Advanced usage
 
 **Changing action's positions** ([demo](http://symfony-collection.fuz.org/symfony3/advanced/customFormTheme))
@@ -579,8 +615,8 @@ In the plugin options:
          prefix: 'parent',
          children: [{
              selector: '.child-collection',
-             prefix: 'child',
-             ...
+             prefix: 'child'
+             // ...
          }]
      });
 ```

--- a/jquery.collection.js
+++ b/jquery.collection.js
@@ -74,6 +74,7 @@
             prototype_name: '__name__',
             name_prefix: null,
             elements_selector: '> div',
+            elements_parent_selector: null,
             children: null,
             init_with_n_elements: 0,
             hide_useless_buttons: true,
@@ -314,13 +315,14 @@
         // (buttons enabled, minimum/maximum of elements not yet reached, rescue
         // button creation when no more elements are remaining...)
         var dumpCollectionActions = function (collection, settings, isInitialization, event) {
-            var init = collection.find('.' + settings.prefix + '-tmp').length === 0;
+            var init = $(settings.container).find('.' + settings.prefix + '-tmp').length === 0;
             var elements = collection.find(settings.elements_selector);
 
             // add a rescue button that will appear only if collection is emptied
             if (settings.allow_add) {
                 if (init) {
-                    collection.append('<span class="' + settings.prefix + '-tmp"></span>');
+                    var elementsParent = $(settings.elements_parent_selector);
+                    elementsParent.append('<span class="' + settings.prefix + '-tmp"></span>');
                     if (settings.add) {
                         collection.append(
                             $(settings.add)
@@ -477,7 +479,7 @@
                 }
                 var regexp = new RegExp(pregQuote(settings.prototype_name), 'g');
                 var code = $(prototype.replace(regexp, freeIndex));
-                var tmp = collection.find('> .' + settings.prefix + '-tmp');
+                var tmp = $(settings.container).find('> .' + settings.prefix + '-tmp');
                 var id = $(code).find('[id]').first().attr('id');
 
                 if (isDuplicate) {
@@ -539,7 +541,7 @@
                     var backup = toDelete.clone({withDataAndEvents: true}).show();
                     toDelete.remove();
                     if (!trueOrUndefined(settings.after_remove(collection, backup))) {
-                        collection.find('> .' + settings.prefix + '-tmp').before(backup);
+                        $(settings.container).find('> .' + settings.prefix + '-tmp').before(backup);
                         elements = collection.find(settings.elements_selector);
                         elements = shiftElementsDown(collection, elements, settings, index - 1);
                     }
@@ -638,6 +640,15 @@
                 }
             } else {
                 collection = elem;
+            }
+
+            // when adding elements to a collection, we should be aware of the node that will contain them
+            if (!settings.elements_parent_selector) {
+                settings.elements_parent_selector = '#' + getOrCreateId('', collection);
+                if ($(settings.elements_parent_selector).length === 0) {
+                    console.log("jquery.collection.js: given elements parent selector does not return any object.");
+                    return true;
+                }
             }
 
             // enforcing logic between options

--- a/jquery.collection.js
+++ b/jquery.collection.js
@@ -74,7 +74,7 @@
             prototype_name: '__name__',
             name_prefix: null,
             elements_selector: '> div',
-            elements_parent_selector: null,
+            elements_parent_selector: '%id%',
             children: null,
             init_with_n_elements: 0,
             hide_useless_buttons: true,
@@ -208,8 +208,10 @@
                 $.each(settings.children, function(key, child) {
                     var childCollection = collection.find(child.selector).eq(index);
                     var childSettings = childCollection.data('collection-settings');
-                    childSettings.name_prefix = childSettings.name_prefix.replace(toReplace, replaceWith);
-                    childCollection.data('collection-settings', childSettings);
+                    if (childSettings) {
+                        childSettings.name_prefix = childSettings.name_prefix.replace(toReplace, replaceWith);
+                        childCollection.data('collection-settings', childSettings);
+                    }
                 });
             }
 
@@ -315,13 +317,13 @@
         // (buttons enabled, minimum/maximum of elements not yet reached, rescue
         // button creation when no more elements are remaining...)
         var dumpCollectionActions = function (collection, settings, isInitialization, event) {
-            var init = $(settings.container).find('.' + settings.prefix + '-tmp').length === 0;
+            var elementsParent = $(settings.elements_parent_selector);
+            var init = elementsParent.find('.' + settings.prefix + '-tmp').length === 0;
             var elements = collection.find(settings.elements_selector);
 
             // add a rescue button that will appear only if collection is emptied
             if (settings.allow_add) {
                 if (init) {
-                    var elementsParent = $(settings.elements_parent_selector);
                     elementsParent.append('<span class="' + settings.prefix + '-tmp"></span>');
                     if (settings.add) {
                         collection.append(
@@ -479,7 +481,8 @@
                 }
                 var regexp = new RegExp(pregQuote(settings.prototype_name), 'g');
                 var code = $(prototype.replace(regexp, freeIndex));
-                var tmp = $(settings.container).find('> .' + settings.prefix + '-tmp');
+                var elementsParent = $(settings.elements_parent_selector);
+                var tmp = elementsParent.find('> .' + settings.prefix + '-tmp');
                 var id = $(code).find('[id]').first().attr('id');
 
                 if (isDuplicate) {
@@ -541,7 +544,8 @@
                     var backup = toDelete.clone({withDataAndEvents: true}).show();
                     toDelete.remove();
                     if (!trueOrUndefined(settings.after_remove(collection, backup))) {
-                        $(settings.container).find('> .' + settings.prefix + '-tmp').before(backup);
+                        var elementsParent = $(settings.elements_parent_selector);
+                        elementsParent.find('> .' + settings.prefix + '-tmp').before(backup);
                         elements = collection.find(settings.elements_selector);
                         elements = shiftElementsDown(collection, elements, settings, index - 1);
                     }
@@ -643,6 +647,7 @@
             }
 
             // when adding elements to a collection, we should be aware of the node that will contain them
+            settings.elements_parent_selector = settings.elements_parent_selector.replace('%id%', '#' + getOrCreateId('', collection));
             if (!settings.elements_parent_selector) {
                 settings.elements_parent_selector = '#' + getOrCreateId('', collection);
                 if ($(settings.elements_parent_selector).length === 0) {

--- a/notes.txt
+++ b/notes.txt
@@ -4,21 +4,10 @@
 -- only once: bower register symfony-collection git://github.com/ninsuo/symfony-collection.git
 
 git push origin master
-git tag -a '2.1.10' -m 'tag'
-git push origin 2.1.10
+git tag -a '2.1.11' -m 'tag'
+git push origin 2.1.11
 
 npm publish
 
 
-todo when online:
-
-create issue to have the ability to relocate rescue add button wherever we want
-
-                    if (settings.add) {
-                        --> collection <--.append(
-                            $(settings.add)
-                                .addClass(settings.prefix + '-action ' + settings.prefix + '-rescue-add')
-                                .data('collection', collection.attr('id'))
-                        );
-                    }
 

--- a/notes.txt
+++ b/notes.txt
@@ -8,3 +8,17 @@ git tag -a '2.1.10' -m 'tag'
 git push origin 2.1.10
 
 npm publish
+
+
+todo when online:
+
+create issue to have the ability to relocate rescue add button wherever we want
+
+                    if (settings.add) {
+                        --> collection <--.append(
+                            $(settings.add)
+                                .addClass(settings.prefix + '-action ' + settings.prefix + '-rescue-add')
+                                .data('collection', collection.attr('id'))
+                        );
+                    }
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "symfony-collection",
-    "version": "2.1.10",
+    "version": "2.1.11",
     "homepage": "http://symfony-collection.fuz.org",
     "description": "A jQuery plugin that manages adding, deleting and moving elements from a Symfony2 collection",
     "keywords": [


### PR DESCRIPTION
**Change the parent selector**

To be able to add elements to the collection, this plugin should be aware of the dom object that will contain them.

By default, your collection elements will be located just below your collection, for example:

```html
    <div id="collection">
       <div id="child_0">(...)</div>
       <div id="child_1">(...)</div>
       <div id="child_2">(...)</div>
    </div>
```

But you may need to put elements deeper in the dom, for example when you put elements in a table:

```html
    <table id="collection">
        <tbody>
            <tr id="child_0">(...)</tr>
            <tr id="child_1">(...)</tr>
            <tr id="child_2">(...)</tr>
        </tbody>
    </table>
```

In that example, parent selector should be `table.collection tbody`.

Note that you can use `%id%` inside `elements_parent_selector`, it will be automatically replaced by the
collection's id. This is particularly useful when you're dealing with nested collections.

Example:

```js
     $('.collection').collection({
        // ...
        children: [{
            // ...
            elements_parent_selector: '%id% tbody'
        }]
     });
```

Default value:

```js
     $('.collection').collection({
        elements_parent_selector: '%id%' // will be the collection itself
     });
```