### PR TITLE
offset starts at element length (filled elements come first)

### DIFF
--- a/jquery.collection.js
+++ b/jquery.collection.js
@@ -353,7 +353,7 @@
 
             // initializes the collection with a minimal number of elements
             if (isInitialization) {
-                collection.data('collection-offset', 0);
+                collection.data('collection-offset', elements.length);
 
                 var container = $(settings.container);
                 var button = collection.find('.' + settings.prefix + '-add, .' + settings.prefix + '-rescue-add, .' + settings.prefix + '-duplicate').first();


### PR DESCRIPTION
This PR should fix issue #113 where `init_with_n_elements` is greater than the minimum number of elements and empty elements are inserted before pre-filled elements.