### PR TITLE
Wrong selector starts an infinite loop

### DIFF
--- a/jquery.collection.js
+++ b/jquery.collection.js
@@ -357,10 +357,16 @@
 
                 var container = $(settings.container);
                 var button = collection.find('.' + settings.prefix + '-add, .' + settings.prefix + '-rescue-add, .' + settings.prefix + '-duplicate').first();
+                var secure = 0;
                 while (elements.length < settings.init_with_n_elements) {
+                    secure++;
                     var element = elements.length > 0 ? elements.last() : undefined;
                     var index = elements.length - 1;
                     elements = doAdd(container, button, collection, settings, elements, element, index, false);
+                    if(secure > settings.init_with_n_elements) {
+                        console.error('Infinite loop, element selector (' + settings.elements_selector + ') not found !!')
+                        break;
+                    }
                 }
 
                 collection.data('collection-offset', elements.length);

--- a/jquery.collection.js
+++ b/jquery.collection.js
@@ -364,7 +364,7 @@
                     var index = elements.length - 1;
                     elements = doAdd(container, button, collection, settings, elements, element, index, false);
                     if(secure > settings.init_with_n_elements) {
-                        console.error('Infinite loop, element selector (' + settings.elements_selector + ') not found !!')
+                        console.error('Infinite loop, element selector (' + settings.elements_selector + ') not found !');
                         break;
                     }
                 }


### PR DESCRIPTION
First of all, thanks for your work, it save my time :D

Because I custom my form or sometime the structure may change, the default selector 

eg```> div``` may fail.

So i add a security to prevent an infinite loop. The user will be prompted in the console, but this is just a proposal.