### PR TITLE
Fix collection arrow buttons when deleting and fading

### DIFF
--- a/jquery.collection.js
+++ b/jquery.collection.js
@@ -405,12 +405,12 @@
                         'enabled': settings.allow_up,
                         'selector': settings.prefix + '-up',
                         'html': settings.up,
-                        'condition': elements.length - delta > 1 && elements.index(element) - delta > 0
+                        'condition': elements.length - delta > 1 && elements.index(element) > 0
                     }, {
                         'enabled': settings.allow_down,
                         'selector': settings.prefix + '-down',
                         'html': settings.down,
-                        'condition': elements.length - delta > 1 && elements.index(element) !== elements.length - 1
+                        'condition': elements.length - delta > 1 && elements.index(element) !== elements.length - 1 - delta
                     }, {
                         'enabled': settings.allow_add && !settings.add_at_the_end && !settings.custom_add_location,
                         'selector': settings.prefix + '-add',


### PR DESCRIPTION
This fixes arrows displaying in the wrong size upon deleting an item in a collection where the `fade_out` is set to true.

Ex in official demo (https://symfony-collection.fuz.org/symfony3/basic/simple-collection):
![image](https://user-images.githubusercontent.com/9340719/47710555-560dfc00-dc33-11e8-9d72-50295d9fb60c.png)

deleting the last item by pressing [ - ] results with:
![image](https://user-images.githubusercontent.com/9340719/47710594-70e07080-dc33-11e8-90d2-7ed8aedb0cbb.png)

the arrow on the second item should be facing up instead of down.

This pull request aims to fix this