### PR TITLE
Fix Twig deprecation warning

### DIFF
--- a/jquery.collection.html.twig
+++ b/jquery.collection.html.twig
@@ -20,7 +20,7 @@
 #}
 
 {% block collection_widget %}
-    {% spaceless %}
+    {% apply spaceless %}
         {% if prototype is defined %}
             {% set attr = attr|merge({'data-prototype': form_row(prototype)}) %}
             {% set attr = attr|merge({'data-prototype-name': prototype.vars.name}) %}


### PR DESCRIPTION
> The spaceless tag in "magic_link/jquery.collection.html.twig" at line 23 is deprecated since Twig 2.7, use the spaceless filter instead.

This small changes converts the `spaceless` tag into a filter (through the `apply` tag).